### PR TITLE
Do not emit stats if connection has not been stablished

### DIFF
--- a/src/rabbit_web_mqtt_handler.erl
+++ b/src/rabbit_web_mqtt_handler.erl
@@ -186,6 +186,11 @@ maybe_emit_stats(State) ->
     rabbit_event:if_enabled(State, #state.stats_timer,
                                 fun() -> emit_stats(State) end).
 
+emit_stats(State=#state{connection = C}) when C == none; C == undefined ->
+    %% Avoid emitting stats on terminate when the connection has not yet been
+    %% established, as this causes orphan entries on the stats database
+    State1 = rabbit_event:reset_stats_timer(State, #state.stats_timer),
+    State1;
 emit_stats(State=#state{socket=Sock, connection=Conn}) ->
     SockInfos = case rabbit_net:getstat(Sock,
             [recv_oct, recv_cnt, send_oct, send_cnt, send_pend]) of


### PR DESCRIPTION
Ensures stats are not emitted until the connection is stablished.
A non-pid value crashes the stats gc.

Part of https://github.com/rabbitmq/rabbitmq-management-agent/issues/42