### PR TITLE
Ensure cuttlefish schema is used correctly

### DIFF
--- a/priv/schema/rabbitmq_web_mqtt.schema
+++ b/priv/schema/rabbitmq_web_mqtt.schema
@@ -3,20 +3,35 @@
 {mapping, "web_mqtt.num_acceptors.ssl", "rabbitmq_web_mqtt.num_ssl_acceptors", 
     [{datatype, integer}]}.
 
-{mapping, "web_mqtt.tcp.port", "rabbitmq_web_mqtt.tcp_config.port",
-    [{datatype, integer}]}.
 {mapping, "web_mqtt.tcp.backlog", "rabbitmq_web_mqtt.tcp_config.backlog",
     [{datatype, integer}]}.
+{mapping, "web_mqtt.tcp.listener", "rabbitmq_web_mqtt.tcp_config",
+    [{datatype, ip}]}.
 {mapping, "web_mqtt.tcp.ip", "rabbitmq_web_mqtt.tcp_config.ip",
     [{datatype, string}, {validators, ["is_ip"]}]}.
-
-
-{mapping, "web_mqtt.ssl.port", "rabbitmq_web_mqtt.ssl_config.port",
+{mapping, "web_mqtt.tcp.port", "rabbitmq_web_mqtt.tcp_config.port",
     [{datatype, integer}]}.
+
+{translation,
+    "rabbitmq_web_mqtt.tcp_config",
+    fun(Conf) ->
+        Setting = cuttlefish:conf_get("web_mqtt.tcp.listener", Conf),
+        case Setting of
+            {Ip, Port} when is_list(Ip), is_integer(Port) ->
+                [{ip, Ip}, {port, Port}];
+            _ -> Setting
+        end
+    end
+}.
+
 {mapping, "web_mqtt.ssl.backlog", "rabbitmq_web_mqtt.ssl_config.backlog",
     [{datatype, integer}]}.
+{mapping, "web_mqtt.ssl.listener", "rabbitmq_web_mqtt.ssl_config",
+    [{datatype, ip}]}.
 {mapping, "web_mqtt.ssl.ip", "rabbitmq_web_mqtt.ssl_config.ip",
     [{datatype, string}, {validators, ["is_ip"]}]}.
+{mapping, "web_mqtt.ssl.port", "rabbitmq_web_mqtt.ssl_config.port",
+    [{datatype, integer}]}.
 {mapping, "web_mqtt.ssl.certfile", "rabbitmq_web_mqtt.ssl_config.certfile",
     [{datatype, string}, {validators, ["file_accessible"]}]}.
 {mapping, "web_mqtt.ssl.keyfile", "rabbitmq_web_mqtt.ssl_config.keyfile",
@@ -26,6 +41,17 @@
 {mapping, "web_mqtt.ssl.password", "rabbitmq_web_mqtt.ssl_config.password",
     [{datatype, string}]}.
 
+{translation,
+    "rabbitmq_web_mqtt.ssl_config",
+    fun(Conf) ->
+        Setting = cuttlefish:conf_get("web_mqtt.ssl.listener", Conf),
+        case Setting of
+            {Ip, Port} when is_list(Ip), is_integer(Port) ->
+                [{ip, Ip}, {port, Port}];
+            _ -> Setting
+        end
+    end
+}.
 
 {mapping, "web_mqtt.cowboy_opts.max_empty_lines", "rabbitmq_web_mqtt.cowboy_opts.max_empty_lines",
     [{datatype, integer}]}.

--- a/test/config_schema_SUITE_data/rabbitmq_web_mqtt.snippets
+++ b/test/config_schema_SUITE_data/rabbitmq_web_mqtt.snippets
@@ -1,10 +1,32 @@
-[{port,
-  "web_mqtt.tcp.port = 12345",
+[{listener,
+  "web_mqtt.tcp.listener = 127.0.0.1:12345",
   [{rabbitmq_web_mqtt,
-    [{tcp_config, [{port,12345}]}]}],
+    [{tcp_config, [{ip,"127.0.0.1"},{port,12345}]}]}],
+  [rabbitmq_web_mqtt]},
+ {tcp_config,
+  "web_mqtt.tcp.ip = 127.0.0.3
+   web_mqtt.tcp.port = 11122",
+  [{rabbitmq_web_mqtt,
+    [{tcp_config, [{ip,"127.0.0.3"},{port,11122}]}]}],
+  [rabbitmq_web_mqtt]},
+ {tcp_config_ip,
+  "web_mqtt.tcp.ip = 127.0.0.3",
+  [{rabbitmq_web_mqtt,
+    [{tcp_config, [{ip,"127.0.0.3"}]}]}],
+  [rabbitmq_web_mqtt]},
+ {tcp_config_port,
+  "web_mqtt.tcp.port = 34567",
+  [{rabbitmq_web_mqtt,
+    [{tcp_config, [{port,34567}]}]}],
+  [rabbitmq_web_mqtt]},
+ {ssl_listener,
+  "web_mqtt.ssl.listener = 127.0.0.4:15672",
+  [{rabbitmq_web_mqtt,
+    [{ssl_config, [{ip,"127.0.0.4"},{port,15672}]}]}],
   [rabbitmq_web_mqtt]},
  {ssl,
-  "web_mqtt.ssl.port = 15671
+  "web_mqtt.ssl.ip         = 127.0.0.2
+   web_mqtt.ssl.port       = 15671
    web_mqtt.ssl.backlog    = 1024
    web_mqtt.ssl.certfile   = test/config_schema_SUITE_data/certs/cert.pem
    web_mqtt.ssl.keyfile    = test/config_schema_SUITE_data/certs/key.pem
@@ -12,7 +34,8 @@
    web_mqtt.ssl.password   = changeme",
   [{rabbitmq_web_mqtt,
        [{ssl_config,
-            [{port,15671},
+            [{ip,"127.0.0.2"},
+             {port,15671},
              {backlog,1024},
              {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
              {keyfile,"test/config_schema_SUITE_data/certs/key.pem"},


### PR DESCRIPTION
Fixes #26 

Tested with the following conf file:

```
web_mqtt.tcp.listener = 127.0.0.1:12345
```

and Erlang-term format file:

```
[
    {rabbitmq_web_mqtt, [
        {tcp_config, [
            {ip, {127,0,0,1}},
            {port, 12345}
        ]}
    ]}
].
```