### PR TITLE
Make it possible to configure Cowboy WebSocket options

### DIFF
--- a/priv/schema/rabbitmq_web_mqtt.schema
+++ b/priv/schema/rabbitmq_web_mqtt.schema
@@ -71,7 +71,7 @@
     [{datatype, integer}]}.
 
 %% backwards compatibility
-{mapping, "web_mqtt.cowboy_opts.timeout",      "rabbitmq_web_mqtt.cowboy_opts.idle_timeout",
+{mapping, "web_mqtt.cowboy_opts.timeout", "rabbitmq_web_mqtt.cowboy_opts.idle_timeout",
     [{datatype, integer}, {validators, ["non_negative_integer"]}]
 }.
 %% recent Cowboy versions have several timeout settings
@@ -95,7 +95,8 @@
 }.
 
 {mapping, "web_mqtt.ws_opts.compress", "rabbitmq_web_mqtt.cowboy_ws_opts.compress",
-    [{datatype, {enum, [true, false]}}]}.
+    [{datatype, {enum, [true, false]}}]
+}.
 {mapping, "web_mqtt.ws_opts.max_frame_size", "rabbitmq_web_mqtt.cowboy_ws_opts.max_frame_size",
     [{datatype, integer}, {validators, ["non_negative_integer"]}]
 }.

--- a/priv/schema/rabbitmq_web_mqtt.schema
+++ b/priv/schema/rabbitmq_web_mqtt.schema
@@ -67,5 +67,38 @@
     [{datatype, integer}]}.
 {mapping, "web_mqtt.cowboy_opts.max_request_line_length", "rabbitmq_web_mqtt.cowboy_opts.max_request_line_length",
     [{datatype, integer}]}.
-{mapping, "web_mqtt.cowboy_opts.timeout", "rabbitmq_web_mqtt.cowboy_opts.timeout",
+{mapping, "web_mqtt.cowboy_opts.timeout", "rabbitmq_web_mqtt.cowboy_opts.idle_timeout",
     [{datatype, integer}]}.
+
+%% backwards compatibility
+{mapping, "web_mqtt.cowboy_opts.timeout",      "rabbitmq_web_mqtt.cowboy_opts.idle_timeout",
+    [{datatype, integer}, {validators, ["non_negative_integer"]}]
+}.
+%% recent Cowboy versions have several timeout settings
+{mapping, "web_mqtt.cowboy_opts.idle_timeout", "rabbitmq_web_mqtt.cowboy_opts.idle_timeout",
+    [{datatype, integer}]
+}.
+
+{translation,
+    "rabbitmq_web_mqtt.cowboy_opts.idle_timeout",
+    fun(Conf) ->
+        case cuttlefish:conf_get("web_mqtt.cowboy_opts.timeout", Conf, undefined) of
+            Value when is_integer(Value) ->
+                Value;
+            undefined ->
+                case cuttlefish:conf_get("web_mqtt.cowboy_opts.idle_timeout", Conf, undefined) of
+                    undefined -> cuttlefish:unset();
+                    Value     -> Value
+                end
+        end
+    end
+}.
+
+{mapping, "web_mqtt.ws_opts.compress", "rabbitmq_web_mqtt.cowboy_ws_opts.compress",
+    [{datatype, {enum, [true, false]}}]}.
+{mapping, "web_mqtt.ws_opts.max_frame_size", "rabbitmq_web_mqtt.cowboy_ws_opts.max_frame_size",
+    [{datatype, integer}, {validators, ["non_negative_integer"]}]
+}.
+{mapping, "web_mqtt.ws_opts.idle_timeout", "rabbitmq_web_mqtt.cowboy_ws_opts.idle_timeout",
+    [{datatype, integer}, {validators, ["non_negative_integer"]}]
+}.

--- a/src/rabbit_web_mqtt_app.erl
+++ b/src/rabbit_web_mqtt_app.erl
@@ -45,10 +45,11 @@ init([]) -> {ok, {{one_for_one, 1, 5}, []}}.
 %%----------------------------------------------------------------------------
 
 mqtt_init() ->
-    CowboyOpts0 = maps:from_list(get_env(cowboy_opts, [])),
+    CowboyOpts0  = maps:from_list(get_env(cowboy_opts, [])),
+    CowboyWsOpts = maps:from_list(get_env(cowboy_ws_opts, [])),
 
     Routes = cowboy_router:compile([{'_', [
-        {get_env(ws_path, "/ws"), rabbit_web_mqtt_handler, []}
+        {get_env(ws_path, "/ws"), rabbit_web_mqtt_handler, [{ws_opts, CowboyWsOpts}]}
     ]}]),
     CowboyOpts = CowboyOpts0#{env         => #{dispatch => Routes},
                               middlewares => [cowboy_router, rabbit_web_mqtt_middleware, cowboy_handler]},

--- a/src/rabbit_web_mqtt_handler.erl
+++ b/src/rabbit_web_mqtt_handler.erl
@@ -46,7 +46,8 @@ init(Req, Opts) ->
                 SecWsProtocol ->
                     cowboy_req:set_resp_header(<<"sec-websocket-protocol">>, SecWsProtocol, Req)
             end,
-            WsOpts = proplists:get_value(ws_opts, Opts, #{}),
+            WsOpts0 = proplists:get_value(ws_opts, Opts, #{}),
+            WsOpts  = maps:merge(#{compress => true}, WsOpts0),
             {cowboy_websocket, Req2, #state{
                 conn_name     = ConnStr,
                 keepalive     = {none, none},

--- a/src/rabbit_web_mqtt_handler.erl
+++ b/src/rabbit_web_mqtt_handler.erl
@@ -46,13 +46,14 @@ init(Req, Opts) ->
                 SecWsProtocol ->
                     cowboy_req:set_resp_header(<<"sec-websocket-protocol">>, SecWsProtocol, Req)
             end,
+            WsOpts = proplists:get_value(ws_opts, Opts, #{}),
             {cowboy_websocket, Req2, #state{
                 conn_name     = ConnStr,
                 keepalive     = {none, none},
                 keepalive_sup = KeepaliveSup,
                 parse_state   = rabbit_mqtt_frame:initial_state(),
                 socket        = Sock
-            }};
+            }, WsOpts};
         _ ->
             {stop, Req}
     end.

--- a/test/config_schema_SUITE_data/rabbitmq_web_mqtt.snippets
+++ b/test/config_schema_SUITE_data/rabbitmq_web_mqtt.snippets
@@ -49,7 +49,47 @@
     [{ws_path, "/rmq/ws"}]}],
   [rabbitmq_web_mqtt]},
 
+ %%
+ %% Cowboy options
+ %%
+
  {cowboy_max_keepalive,
   "web_mqtt.cowboy_opts.max_keepalive = 10",
-  [{rabbitmq_web_mqtt,[{cowboy_opts,[{max_keepalive,10}]}]}],
-  [rabbitmq_web_mqtt]}].
+  [{rabbitmq_web_mqtt,[{cowboy_opts,[{max_keepalive, 10}]}]}],
+  [rabbitmq_web_mqtt]},
+
+ {cowboy_timeout,
+  "web_mqtt.cowboy_opts.timeout = 10000",
+  [{rabbitmq_web_mqtt,[{cowboy_opts,[{idle_timeout, 10000}]}]}],
+  [rabbitmq_web_mqtt]},
+
+ {cowboy_idle_timeout,
+  "web_mqtt.cowboy_opts.idle_timeout = 10000",
+  [{rabbitmq_web_mqtt,[{cowboy_opts,[{idle_timeout, 10000}]}]}],
+  [rabbitmq_web_mqtt]},
+
+ %%
+ %% Cowboy WebSocket options
+ %%
+
+{ws_opts_compress_true,
+  "web_mqtt.ws_opts.compress = true",
+  [{rabbitmq_web_mqtt,[{cowboy_ws_opts,[{compress, true}]}]}],
+  [rabbitmq_web_mqtt]},
+
+{ws_opts_compress_false,
+  "web_mqtt.ws_opts.compress = false",
+  [{rabbitmq_web_mqtt,[{cowboy_ws_opts,[{compress, false}]}]}],
+  [rabbitmq_web_mqtt]},
+
+{ws_opts_max_frame_size,
+  "web_mqtt.ws_opts.max_frame_size = 8000",
+  [{rabbitmq_web_mqtt,[{cowboy_ws_opts,[{max_frame_size, 8000}]}]}],
+  [rabbitmq_web_mqtt]},
+
+{ws_idle_timeout,
+  "web_mqtt.ws_opts.idle_timeout = 10000",
+  [{rabbitmq_web_mqtt,[{cowboy_ws_opts,[{idle_timeout, 10000}]}]}],
+  [rabbitmq_web_mqtt]}
+].
+


### PR DESCRIPTION
This makes it possible to configure WebSocket options as well as timeouts in modern Cowboy versions (2.4.x in `master` and `v3.7.x`). Just like in https://github.com/rabbitmq/rabbitmq-web-stomp/pull/91, compression is enabled by default.

To see if compression enabled with various configuration settings, use `rabbitmq_web_stomp_examples`, open an example app and see the `sec-websocket-extensions` request and response headers in browser developer tools.

[#161053821]