### PR TITLE
Support web_mqtt.ssl.listener combined with other web_mqtt.ssl.* settings

### DIFF
--- a/priv/schema/rabbitmq_web_mqtt.schema
+++ b/priv/schema/rabbitmq_web_mqtt.schema
@@ -28,11 +28,12 @@
     end
 }.
 
-{mapping, "web_mqtt.ssl.backlog", "rabbitmq_web_mqtt.ssl_config.backlog",
-    [{datatype, integer}]}.
 {mapping, "web_mqtt.ssl.listener", "rabbitmq_web_mqtt.ssl_config", [
     {datatype, [{enum, [none]}, ip]}
 ]}.
+
+{mapping, "web_mqtt.ssl.backlog", "rabbitmq_web_mqtt.ssl_config.backlog",
+    [{datatype, integer}]}.
 {mapping, "web_mqtt.ssl.ip", "rabbitmq_web_mqtt.ssl_config.ip",
     [{datatype, string}, {validators, ["is_ip"]}]}.
 {mapping, "web_mqtt.ssl.port", "rabbitmq_web_mqtt.ssl_config.port",
@@ -51,11 +52,21 @@
     fun(Conf) ->
         Setting = cuttlefish:conf_get("web_mqtt.ssl.listener", Conf, undefined),
         case Setting of
-            none -> [];
+            none      -> cuttlefish:unset();
             undefined -> [];
             {Ip, Port} when is_list(Ip), is_integer(Port) ->
-                [{ip, Ip}, {port, Port}];
-            _ -> Setting
+                %% we redo some of Cuttlefish's work here to
+                %% populate rabbitmq_web_mqtt.ssl_config here
+                TLSConf   = cuttlefish_variable:filter_by_prefix("web_mqtt.ssl", Conf),
+                %% preserve all web_mqtt.ssl.* keys in rabbitmq_web_mqtt.ssl_config
+                TLSConfM0 = maps:fold(fun(Path, V, Acc) ->
+                                              maps:put(list_to_atom(lists:last(Path)), V, Acc)
+                                      end, #{}, maps:from_list(TLSConf)),
+                TLSConfM  = maps:remove(listener, TLSConfM0),
+                ListenerM = maps:from_list([{ip, Ip}, {port, Port}]),
+                lists:keysort(1, maps:to_list(maps:merge(TLSConfM, ListenerM)));
+
+            _         -> Setting
         end
     end
 }.

--- a/test/config_schema_SUITE_data/rabbitmq_web_mqtt.snippets
+++ b/test/config_schema_SUITE_data/rabbitmq_web_mqtt.snippets
@@ -31,9 +31,27 @@
   [rabbitmq_web_mqtt]},
  {ssl_listener_none,
   "web_mqtt.ssl.listener = none",
-  [{rabbitmq_web_mqtt,
-    [{ssl_config, []}]}],
+  [],
   [rabbitmq_web_mqtt]},
+
+ {ssl_with_listener,
+  "web_mqtt.ssl.listener   = 127.0.0.2:15671
+   web_mqtt.ssl.backlog    = 1024
+   web_mqtt.ssl.certfile   = test/config_schema_SUITE_data/certs/cert.pem
+   web_mqtt.ssl.keyfile    = test/config_schema_SUITE_data/certs/key.pem
+   web_mqtt.ssl.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
+   web_mqtt.ssl.password   = changeme",
+  [{rabbitmq_web_mqtt,
+       [{ssl_config,
+            [{ip,"127.0.0.2"},
+             {port,15671},
+             {backlog,1024},
+             {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
+             {keyfile,"test/config_schema_SUITE_data/certs/key.pem"},
+             {cacertfile,"test/config_schema_SUITE_data/certs/cacert.pem"},
+             {password,"changeme"}]}]}],
+  [rabbitmq_web_mqtt]},
+
  {ssl,
   "web_mqtt.ssl.ip         = 127.0.0.2
    web_mqtt.ssl.port       = 15671


### PR DESCRIPTION
The following configuration didn't work as expected previously because all keys but interface and port were omitted from the generated file:

```
web_stomp.ssl.listener    = 0.0.0.0:12345
web_stomp.ssl.cacertfile = /path/to/tls-gen.git/basic/result/ca_certificate.pem
web_stomp.ssl.certfile     = /path/to/tls-gen.git/basic/result/server_certificate.pem
web_stomp.ssl.keyfile      = /path/to/tls-gen.git/basic/result/server_key.pem
```

Closes #48.