### PR TITLE
Send will when client connection stops

### DIFF
--- a/src/rabbit_web_mqtt_handler.erl
+++ b/src/rabbit_web_mqtt_handler.erl
@@ -162,6 +162,7 @@ terminate(_, _, State = #state{ proc_state = ProcState,
                                 conn_name  = ConnName }) ->
     maybe_emit_stats(State),
     rabbit_log_connection:info("closing Web MQTT connection ~p (~s)~n", [self(), ConnName]),
+    rabbit_mqtt_processor:send_will(ProcState),
     rabbit_mqtt_processor:close_connection(ProcState),
     ok.
 


### PR DESCRIPTION
This is a fix to issues raised in the following threads:
https://github.com/rabbitmq/rabbitmq-web-mqtt/issues/23
https://groups.google.com/forum/#!searchin/rabbitmq-users/last$20will%7Csort:date/rabbitmq-users/Jg88NdgcNPY/1w7LzK10CQAJ

The change is committed so that behaviour will be similar to the rabbitmq-mqtt plugin wherein the lastwill message is dispatched by broker when the mqtt client is killed or died ungracefully.
