### PR TITLE
Maintenance mode event support

### DIFF
--- a/src/rabbit_web_mqtt_app.erl
+++ b/src/rabbit_web_mqtt_app.erl
@@ -50,8 +50,8 @@ prep_stop(State) ->
 
 -spec stop(_) -> ok.
 stop(_State) ->
-    stop_ranch_listener(?TCP_PROTOCOL),
-    stop_ranch_listener(?TLS_PROTOCOL),
+    rabbit_networking:stop_ranch_listener_of_protocol(?TCP_PROTOCOL),
+    rabbit_networking:stop_ranch_listener_of_protocol(?TLS_PROTOCOL),
     ok.
 
 init([]) -> {ok, {{one_for_one, 1, 5}, []}}.
@@ -72,13 +72,6 @@ close_all_client_connections(Reason) ->
 %%
 %% Implementation
 %%
-
-stop_ranch_listener(Protocol) ->
-    case rabbit_networking:ranch_ref_of_protocol(Protocol) of
-        {error, not_found} -> ok;
-        undefined          -> ok;
-        Ref                -> ranch:stop_listener(Ref)
-    end.
 
 connection_pids_of_protocol(Protocol) ->
     case rabbit_networking:ranch_ref_of_protocol(Protocol) of

--- a/src/rabbit_web_mqtt_app.erl
+++ b/src/rabbit_web_mqtt_app.erl
@@ -24,7 +24,14 @@
 -behaviour(supervisor).
 -export([init/1]).
 
-%%----------------------------------------------------------------------------
+-import(rabbit_misc, [pget/2]).
+
+-define(TCP_PROTOCOL, 'http/web-mqtt').
+-define(TLS_PROTOCOL, 'https/web-mqtt').
+
+%%
+%% API
+%%
 
 -spec start(_, _) -> {ok, pid()}.
 start(_Type, _StartArgs) ->
@@ -33,16 +40,25 @@ start(_Type, _StartArgs) ->
 
 -spec prep_stop(term()) -> term().
 prep_stop(State) ->
-    ranch:stop_listener(web_mqtt),
     State.
 
 -spec stop(_) -> ok.
 stop(_State) ->
+    case rabbit_networking:ranch_ref_of_protocol(?TCP_PROTOCOL) of
+        {error, not_found} -> ok;
+        Ref1               -> ranch:stop_listener(Ref1)
+    end,
+    case rabbit_networking:ranch_ref_of_protocol(?TLS_PROTOCOL) of
+        {error, not_found} -> ok;
+        Ref2               -> ranch:stop_listener(Ref2)
+    end,
     ok.
 
 init([]) -> {ok, {{one_for_one, 1, 5}, []}}.
 
-%%----------------------------------------------------------------------------
+%%
+%% Implementation
+%%
 
 mqtt_init() ->
   CowboyOpts0  = maps:from_list(get_env(cowboy_opts, [])),
@@ -72,7 +88,7 @@ start_tcp_listener(TCPConf0, CowboyOpts) ->
     max_connections => get_max_connections(),
     num_acceptors => get_env(num_tcp_acceptors, 10)
   },
-  case ranch:start_listener(web_mqtt,
+  case ranch:start_listener(rabbit_networking:ranch_ref(TCPConf),
                             ranch_tcp,
                             RanchTransportOpts,
                             rabbit_web_mqtt_connection_sup,
@@ -86,7 +102,7 @@ start_tcp_listener(TCPConf0, CowboyOpts) ->
               [ErrTCP, TCPConf]),
           throw(ErrTCP)
   end,
-  listener_started('http/web-mqtt', TCPConf),
+  listener_started(?TCP_PROTOCOL, TCPConf),
   rabbit_log:info("rabbit_web_mqtt: listening for HTTP connections on ~s:~w~n",
                   [IpStr, Port]).
 
@@ -99,7 +115,7 @@ start_tls_listener(TLSConf0, CowboyOpts) ->
     max_connections => get_max_connections(),
     num_acceptors => get_env(num_ssl_acceptors, 10)
   },
-  case ranch:start_listener(web_mqtt_secure,
+  case ranch:start_listener(rabbit_networking:ranch_ref(TLSConf),
                             ranch_ssl,
                             RanchTransportOpts,
                             rabbit_web_mqtt_connection_sup,
@@ -113,7 +129,7 @@ start_tls_listener(TLSConf0, CowboyOpts) ->
               [ErrTLS, TLSConf]),
           throw(ErrTLS)
   end,
-  listener_started('https/web-mqtt', TLSConf),
+  listener_started(?TLS_PROTOCOL, TLSConf),
   rabbit_log:info("rabbit_web_mqtt: listening for HTTPS connections on ~s:~w~n",
                   [TLSIpStr, TLSPort]).
 

--- a/src/rabbit_web_mqtt_handler.erl
+++ b/src/rabbit_web_mqtt_handler.erl
@@ -17,11 +17,14 @@
 -module(rabbit_web_mqtt_handler).
 -behaviour(cowboy_websocket).
 
--export([init/2]).
--export([websocket_init/1]).
--export([websocket_handle/2]).
--export([websocket_info/2]).
--export([terminate/3]).
+-export([
+    init/2,
+    websocket_init/1,
+    websocket_handle/2,
+    websocket_info/2,
+    terminate/3
+]).
+-export([close_connection/2]).
 
 -include_lib("amqp_client/include/amqp_client.hrl").
 
@@ -88,6 +91,13 @@ websocket_init(State = #state{conn_name = ConnStr, socket = Sock, peername = Pee
          #state.stats_timer),
      hibernate}.
 
+-spec close_connection(pid(), string()) -> 'ok'.
+close_connection(Pid, Reason) ->
+    rabbit_log_connection:info("Web MQTT: will terminate connection process ~p, reason: ~s",
+                               [Pid, Reason]),
+    sys:terminate(Pid, Reason),
+    ok.
+
 websocket_handle({binary, Data}, State) ->
     handle_data(Data, State);
 %% Silently ignore ping and pong frames.
@@ -132,8 +142,13 @@ websocket_info({'EXIT', _, _}, State) ->
     stop(State);
 websocket_info({'$gen_cast', duplicate_id}, State = #state{ proc_state = ProcState,
                                                                  conn_name = ConnName }) ->
-    rabbit_log_connection:warning("Web MQTT disconnecting duplicate client id ~p (~p)~n",
+    rabbit_log_connection:warning("Web MQTT disconnecting a client with duplicate ID '~s' (~p)~n",
                  [rabbit_mqtt_processor:info(client_id, ProcState), ConnName]),
+    stop(State);
+websocket_info({'$gen_cast', {close_connection, Reason}}, State = #state{ proc_state = ProcState,
+                                                                 conn_name = ConnName }) ->
+    rabbit_log_connection:warning("Web MQTT disconnecting client with ID '~s' (~p), reason: ~s~n",
+                 [rabbit_mqtt_processor:info(client_id, ProcState), ConnName, Reason]),
     stop(State);
 websocket_info({start_keepalives, Keepalive},
                State = #state{ socket = Sock, keepalive_sup = KeepaliveSup }) ->

--- a/test/src/rabbit_ws_test_util.erl
+++ b/test/src/rabbit_ws_test_util.erl
@@ -25,10 +25,6 @@ update_app_env(Config, Key, Val) ->
     ok = rabbit_ct_broker_helpers:rpc(Config, 0,
                                       application, stop,
                                       [rabbitmq_web_mqtt]),
-    rabbit_ct_broker_helpers:rpc(Config, 0,
-                                      ranch, stop_listener,
-                                      [web_mqtt]),
-    rabbit_ct_broker_helpers:rpc(Config, 0, ranch, stop_listener, [web_mqtt_secure]),
     ok = rabbit_ct_broker_helpers:rpc(Config, 0,
                                       application, start,
                                       [rabbitmq_web_mqtt]).


### PR DESCRIPTION
This makes the refs predictable and easy to compute
from a listener record. Then suspending all listeners
becomes a lot simpler.

We also introduce a way to list and shut down all Web MQTT client
connections. Kudos to @essen for explaining what'd be the best way to do that
with Ranch. While MQTT plugin will close connections on our behalf
(we just have to handle this gracefully), such functions are still
useful to have.

While at it, make protocol applications clean up
their listeners when they stop. This way tests
and other callers that have to stop the app
would not need to know anything about
its listeners.

Part of rabbitmq/rabbitmq-server#2321